### PR TITLE
Remove clean_pytex in clean in the make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,4 +165,4 @@ clean_pytex:
 	rm -f $(ALL_SCHPY:.py=.tex)
 
 .PHONY: clean
-clean: clean_tex clean_log clean_eps clean_pytex
+clean: clean_tex clean_log clean_eps


### PR DESCRIPTION
Issue: #17
This PR removed clean_pytex in clean in the make file, which fix the problem discovered with [#5 (comment)](https://github.com/solvcon/mmnote/issues/5#issuecomment-1287360243)