### PR TITLE
ci(doc): archive PDF files

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -28,3 +28,10 @@ jobs:
     - name: make
       run: |
         make
+
+    - name: Archive PDF
+      uses: actions/upload-artifact@v3
+      with:
+        name: archive PDF
+        path: |
+          *.pdf


### PR DESCRIPTION
Issue: #5

Reserve the generated PDFs during CI build. Users can download the PDF files via Github web UI or command line. See here about how-to https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts?tool=webui and an example https://github.com/tai271828/mmnote/actions/runs/3544453194 .