### PR TITLE
Upgrade github actions

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -10,13 +10,15 @@ jobs:
 
   build_pdf:
 
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && vars.MMNOTE_NIGHTLY == 'enable') }}
+
     name: build_pdf
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
 
@@ -36,7 +38,7 @@ jobs:
         make lint
 
     - name: Archive PDF
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: archive PDF
         path: |


### PR DESCRIPTION
* Upgrade ubuntu from 20.04 to 22.04
* Upgrade checkout action from v1 to v4
* Upgrade upload-artifact action from v3 to v4
* Use the repository variable `MMNOTE-NIGHTLY` to control nightly run